### PR TITLE
Add an API route that converts text to vector embeddings using OpenAI API

### DIFF
--- a/ayushma/api_router.py
+++ b/ayushma/api_router.py
@@ -3,7 +3,7 @@ from django.urls import include, path
 from rest_framework_nested import routers
 
 from .views.auth import APILoginView, APILogoutView
-from .views.chat import TextToVector
+from .views.chat import ChatViewSet
 from .views.users import UserViewSet
 
 app_name = "api"
@@ -25,5 +25,5 @@ auth_urls = [
 urlpatterns = [
     path(r"", include(router.urls)),
     path("auth/", include(auth_urls)),
-    path("chat", TextToVector.as_view()),
+    path("chat", ChatViewSet.as_view()),
 ]

--- a/ayushma/api_router.py
+++ b/ayushma/api_router.py
@@ -3,6 +3,7 @@ from django.urls import include, path
 from rest_framework_nested import routers
 
 from .views.auth import APILoginView, APILogoutView
+from .views.chat import TextToVector
 from .views.users import UserViewSet
 
 app_name = "api"
@@ -24,4 +25,5 @@ auth_urls = [
 urlpatterns = [
     path(r"", include(router.urls)),
     path("auth/", include(auth_urls)),
+    path("chat", TextToVector.as_view()),
 ]

--- a/ayushma/utils/openaiapi.py
+++ b/ayushma/utils/openaiapi.py
@@ -1,0 +1,8 @@
+import openai
+from django.conf import settings
+
+
+def get_embedding(text, model="text-embedding-ada-02"):
+    text = text.replace("\n", " ")
+    openai.api_key = settings.OPENAI_API_KEY
+    return openai.Embedding.create(input=[text], model=model)["data"][0]["embedding"]

--- a/ayushma/utils/openaiapi.py
+++ b/ayushma/utils/openaiapi.py
@@ -2,7 +2,7 @@ import openai
 from django.conf import settings
 
 
-def get_embedding(text, model="text-embedding-ada-02"):
+def get_embedding(text, model="text-embedding-ada-002"):
     text = text.replace("\n", " ")
     openai.api_key = settings.OPENAI_API_KEY
     return openai.Embedding.create(input=[text], model=model)["data"][0]["embedding"]

--- a/ayushma/views/chat.py
+++ b/ayushma/views/chat.py
@@ -8,7 +8,7 @@ from rest_framework.views import APIView
 from ..utils.openaiapi import get_embedding
 
 
-class TextToVector(APIView):
+class ChatViewSet(APIView):
     """
     View to convert text to vector embeddings using OpenAI's API
     """

--- a/ayushma/views/chat.py
+++ b/ayushma/views/chat.py
@@ -1,11 +1,36 @@
 import openai
 from django.conf import settings
 from drf_spectacular.utils import extend_schema
-from rest_framework import authentication, permissions
+from rest_framework import authentication, permissions, status
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from ..utils.openaiapi import get_embedding
+
+import tiktoken
+
+def num_tokens_from_string(string: str, encoding_name: str) -> int:
+    """Returns the number of tokens in a text string."""
+    encoding = tiktoken.get_encoding(encoding_name)
+    num_tokens = len(encoding.encode(string))
+    return num_tokens
+
+def n_equal_strings(str):
+    """Returns one string split into n equal length strings"""
+    n = len(str)
+    number_of_strings = int(n / 8192) 
+    number_of_chars = int(n / number_of_strings)
+    equalStr = []
+
+    for i in range(0, n, number_of_chars):
+        try:
+            part = str[i : i + number_of_chars]
+            equalStr.append(part)
+        except:
+            part = str[i : ]
+            equalStr.append(part)
+    
+    return equalStr
 
 
 class ChatViewSet(APIView):
@@ -21,7 +46,17 @@ class ChatViewSet(APIView):
         operation_id="text-to-vector",
     )
     def post(self, request):
+        
         text = request.data.get("text")
         openai.api_key = settings.OPENAI_API_KEY
-        embedding = get_embedding(text=text)
-        return Response({"embedding": embedding})
+        num_tokens = num_tokens_from_string(text, "cl100k_base")
+        
+        if num_tokens < 8192:
+            embedding = get_embedding(text=text)
+            return Response({"embedding": embedding})
+        else:
+            res = []
+            equalStrs = n_equal_strings(text)
+            for str in equalStrs:
+                res.append({"embedding": get_embedding(text=str)})
+            return Response({"embeddings": res})

--- a/ayushma/views/chat.py
+++ b/ayushma/views/chat.py
@@ -15,22 +15,17 @@ def num_tokens_from_string(string: str, encoding_name: str) -> int:
     num_tokens = len(encoding.encode(string))
     return num_tokens
 
-def n_equal_strings(str):
+def split_text(text):
     """Returns one string split into n equal length strings"""
     n = len(str)
-    number_of_strings = int(n / 8192) 
-    number_of_chars = int(n / number_of_strings)
-    equalStr = []
+    number_of_chars = 8192
+    parts = []
 
     for i in range(0, n, number_of_chars):
-        try:
-            part = str[i : i + number_of_chars]
-            equalStr.append(part)
-        except:
-            part = str[i : ]
-            equalStr.append(part)
-    
-    return equalStr
+        part = text[i : i + number_of_chars]
+        parts.append(part)
+
+    return parts
 
 
 class ChatViewSet(APIView):
@@ -56,7 +51,7 @@ class ChatViewSet(APIView):
             return Response({"embedding": embedding})
         else:
             res = []
-            equalStrs = n_equal_strings(text)
-            for str in equalStrs:
-                res.append({"embedding": get_embedding(text=str)})
+            parts = split_text(text)
+            for part in parts:
+                res.append({"embedding": get_embedding(text=part)})
             return Response({"embeddings": res})

--- a/ayushma/views/chat.py
+++ b/ayushma/views/chat.py
@@ -1,0 +1,27 @@
+import openai
+from django.conf import settings
+from drf_spectacular.utils import extend_schema
+from rest_framework import authentication, permissions
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from ..utils.openaiapi import get_embedding
+
+
+class TextToVector(APIView):
+    """
+    View to convert text to vector embeddings using OpenAI's API
+    """
+
+    authentication_classes = [authentication.TokenAuthentication]
+    permission_classes = [permissions.AllowAny]
+
+    @extend_schema(
+        tags=("chat",),
+        operation_id="text-to-vector",
+    )
+    def post(self, request):
+        text = request.data.get("text")
+        openai.api_key = settings.OPENAI_API_KEY
+        embedding = get_embedding(text=text)
+        return Response({"embedding": embedding})

--- a/core/settings/base.py
+++ b/core/settings/base.py
@@ -318,3 +318,5 @@ CORS_ALLOW_ALL_ORIGINS = True
 CORS_ALLOW_HEADERS = list(default_headers) + [
     "sentry-trace",
 ]
+
+OPENAI_API_KEY = env("OPENAI_API_KEY", default="")

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -28,3 +28,4 @@ requests
 openai==0.27.2
 pinecone-client==2.2.1
 PyPDF2==3.0.1
+tiktoken==0.3.3

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -19,3 +19,7 @@ factory-boy==3.2.1  # https://github.com/FactoryBoy/factory_boy
 
 django-debug-toolbar==3.7.0  # https://github.com/jazzband/django-debug-toolbar
 django-extensions==3.2.1  # https://github.com/django-extensions/django-extensions
+
+#OpenAI
+# ------------------------------------------------------------------------------
+openai==0.27.2


### PR DESCRIPTION
Closes #8 
Added an API route that converts a given string of text to vector embeddings (for any use). The API route can be accessed at `/api/chat`

Note: Setup API key in the env before usage