### PR TITLE
Add streaming support to text converse endpoint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
         types: ["python"]
         pass_filenames: false
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.11.5
     hooks:
       - id: isort
   - repo: https://github.com/psf/black

--- a/ayushma/utils/openaiapi.py
+++ b/ayushma/utils/openaiapi.py
@@ -1,12 +1,16 @@
+import json
+from queue import Queue
 from typing import List
 
 import openai
 import tiktoken
+from anyio.from_thread import start_blocking_portal
 from django.conf import settings
 from langchain.schema import AIMessage, HumanMessage
 from pinecone import QueryResponse
 
-from ayushma.models import Chat, ChatMessage, Project
+from ayushma.models import ChatMessage
+from ayushma.models.enums import ChatMessageType
 from ayushma.utils.langchain import LangChainHelper
 
 
@@ -72,7 +76,7 @@ def num_tokens_from_string(string: str, encoding_name: str) -> int:
 
 def split_text(text):
     """Returns one string split into n equal length strings"""
-    n = len(str)
+    n = len(text)
     number_of_chars = 8192
     parts = []
 
@@ -83,14 +87,12 @@ def split_text(text):
     return parts
 
 
-def converse(text, openai_key, chat, match_number):
-    top_k = match_number
+def create_json_response(chat_id, delta, message, stop):
+    json_data = {"chat": str(chat_id), "delta": delta, "message": message, "stop": stop}
+    return "data: " + json.dumps(json_data) + "\n\n"
 
-    if not openai_key:
-        raise Exception("OpenAI-Key header is required to create a chat or converse")
-    openai.api_key = openai_key
-    text = text.replace("\n", " ")
-    nurse_query = ChatMessage.objects.create(message=text, chat=chat, messageType=1)
+
+def get_reference(text, openai_key, chat, top_k):
     num_tokens = num_tokens_from_string(text, "cl100k_base")
     embeddings: List[List[List[float]]] = []
     if num_tokens < 8192:
@@ -125,10 +127,27 @@ def converse(text, openai_key, chat, match_number):
             raise Exception(
                 e.__str__(),
             )
-    reference = get_sanitized_reference(pinecone_references=pinecone_references)
+    return get_sanitized_reference(pinecone_references=pinecone_references)
+
+
+def converse(text, openai_key, chat, match_number):
+    if not openai_key:
+        raise Exception("OpenAI-Key header is required to create a chat or converse")
+    openai.api_key = openai_key
+
+    text = text.replace("\n", " ")
+    nurse_query = ChatMessage.objects.create(message=text, chat=chat, messageType=1)
+
+    reference = get_reference(text, openai_key, chat, match_number)
+
+    token_queue = Queue()
+    RESPONSE_END = object()
     lang_chain_helper = LangChainHelper(
-        openai_api_key=openai_key, prompt_template=chat.project.prompt
+        token_queue=token_queue,
+        openai_api_key=openai_key,
+        prompt_template=chat.project.prompt,
     )
+
     # excluding the latest query since it is not a history
     previous_messages = (
         ChatMessage.objects.filter(chat=chat)
@@ -137,14 +156,34 @@ def converse(text, openai_key, chat, match_number):
     )
     chat_history = []
     for message in previous_messages:
-        if message.messageType == 1:  # type=USER
+        if message.messageType == ChatMessageType.USER:
             chat_history.append(HumanMessage(content=f"Nurse: {message.message}"))
-        elif message.messageType == 3:  # type=AYUSHMA
+        elif message.messageType == ChatMessageType.AYUSHMA:
             chat_history.append(AIMessage(content=f"Ayushma: {message.message}"))
-    response = lang_chain_helper.get_response(
-        user_msg=text, reference=reference, chat_history=chat_history
-    )
-    response = response.replace("Ayushma: ", "")
-    ChatMessage.objects.create(message=response, chat=chat, messageType=3)
 
-    return response
+    with start_blocking_portal() as portal:
+        portal.start_task_soon(
+            lang_chain_helper.get_response,
+            RESPONSE_END,
+            token_queue,
+            text,
+            reference,
+            chat_history,
+        )
+        chat_response = ""
+        while True:
+            if token_queue.empty():
+                continue
+            next_token = token_queue.get(True, timeout=3)
+            if next_token is RESPONSE_END:
+                ChatMessage.objects.create(
+                    message=chat_response,
+                    chat=chat,
+                    messageType=ChatMessageType.AYUSHMA,
+                )
+                yield create_json_response(chat.external_id, "", chat_response, True)
+                break
+            chat_response += next_token
+            yield create_json_response(
+                chat.external_id, next_token, chat_response, False
+            )

--- a/ayushma/utils/stream_callback.py
+++ b/ayushma/utils/stream_callback.py
@@ -1,0 +1,65 @@
+from typing import Any, Dict, List, Union
+
+from langchain.callbacks.base import BaseCallbackHandler
+from langchain.schema import AgentAction, AgentFinish, LLMResult
+
+
+class StreamingQueueCallbackHandler(BaseCallbackHandler):
+    """Callback handler for streaming to Queue."""
+
+    def __init__(self, q):
+        self.q = q
+
+    def on_llm_new_token(self, token: str, **kwargs) -> None:
+        """Run on new LLM token. Streams to Queue."""
+        for char in token:
+            self.q.put(char)
+
+    def on_llm_end(self, response: LLMResult, **kwargs) -> None:
+        """Finish the Queue when the LLM is done."""
+
+    def on_llm_start(
+        self, serialized: Dict[str, Any], prompts: List[str], **kwargs: Any
+    ) -> None:
+        """Run when LLM starts running."""
+
+    def on_llm_error(
+        self, error: Union[Exception, KeyboardInterrupt], **kwargs: Any
+    ) -> None:
+        """Run when LLM errors."""
+
+    def on_chain_start(
+        self, serialized: Dict[str, Any], inputs: Dict[str, Any], **kwargs: Any
+    ) -> None:
+        """Run when chain starts running."""
+
+    def on_chain_end(self, outputs: Dict[str, Any], **kwargs: Any) -> None:
+        """Run when chain ends running."""
+
+    def on_chain_error(
+        self, error: Union[Exception, KeyboardInterrupt], **kwargs: Any
+    ) -> None:
+        """Run when chain errors."""
+
+    def on_tool_start(
+        self, serialized: Dict[str, Any], input_str: str, **kwargs: Any
+    ) -> None:
+        """Run when tool starts running."""
+
+    def on_agent_action(self, action: AgentAction, **kwargs: Any) -> Any:
+        """Run on agent action."""
+        pass
+
+    def on_tool_end(self, output: str, **kwargs: Any) -> None:
+        """Run when tool ends running."""
+
+    def on_tool_error(
+        self, error: Union[Exception, KeyboardInterrupt], **kwargs: Any
+    ) -> None:
+        """Run when tool errors."""
+
+    def on_text(self, text: str, **kwargs: Any) -> None:
+        """Run on arbitrary text."""
+
+    def on_agent_finish(self, finish: AgentFinish, **kwargs: Any) -> None:
+        """Run on agent end."""

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -29,4 +29,7 @@ openai==0.27.2
 pinecone-client==2.2.1
 PyPDF2==3.0.1
 tiktoken==0.3.3
-langchain==0.0.139
+langchain==0.0.160
+
+# For asynchronous event loop
+anyio==3.6.2


### PR DESCRIPTION
Frontend change: https://github.com/coronasafe/ayushma_fe/pull/7

This pull request introduces crucial updates to the backend that enable real-time streaming support for Ayushma (AI) responses. The changes ensure that users can interact with the AI in a more engaging and dynamic manner, as tokens are displayed as soon as they are received from the AI.

- `ChatOpenAI` is initialized with `streaming=True` and with a `callback_manager` which receives each new token as it is received from OpenAI.
- Django's `StreamingHttpResponse` is initialized with `content_type="text/event-stream"` and the LLM's output is streamed to the client in the below format.
- Employed `start_blocking_portal` to initiate the `lang_chain_helper.get_response` coroutine, which retrieves the AI responses in real time and populates the `token_queue` accordingly.
- Each token is added to a queue in the `StreamingQueueCallbackHandler` which is then processed to create a streaming json output.
- Implemented a loop that continuously reads tokens from the token_queue, appending them to the chat_response string and yielding an updated JSON response for each token. The loop terminates when the RESPONSE_END token is encountered.
- Format of message: `{"chat": chat_id, "delta": delta, "message": message, "stop": stop}` where `delta` is the new token received and `message` is the entire message streamed so far.
- Minor fixes such as fixing a logical issue with `split_text` and refactoring the code to use `ChatMessageType` instead of hardcoded numbers are also made.

These backend enhancements work in tandem with the frontend updates to provide a seamless, real-time streaming experience for Ayushma (AI) responses, significantly improving user engagement and interactivity.