### PR TITLE
Increase gunicorn timeout and fixes to llm err handling

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,4 @@
 release: python manage.py migrate
-web: gunicorn core.wsgi:application
+web: gunicorn core.wsgi:application --timeout 180
 # worker: REMAP_SIGTERM=SIGQUIT celery -A core.celery_app worker --loglevel=info
 # beat: REMAP_SIGTERM=SIGQUIT celery -A core.celery_app beat --loglevel=info

--- a/ayushma/utils/language_helpers.py
+++ b/ayushma/utils/language_helpers.py
@@ -32,7 +32,7 @@ language_code_voice_map = {
 
 def sanitize_text(text):
     sanitized_text = re.sub(r"(\*\*|__)(.*?)\1", r"\2", text)  # Remove bold
-    sanitized_text = re.sub(r"(\*|_)(.*?)\1", r"\2", text)  # Remove italic
+    sanitized_text = re.sub(r"(\*|_)(.*?)\1", r"\2", sanitized_text)  # Remove italic
 
     return sanitized_text
 

--- a/ayushma/utils/stream_callback.py
+++ b/ayushma/utils/stream_callback.py
@@ -13,8 +13,7 @@ class StreamingQueueCallbackHandler(BaseCallbackHandler):
 
     def on_llm_new_token(self, token: str, **kwargs) -> None:
         """Run on new LLM token. Streams to Queue."""
-        for char in token:
-            self.q.put(char)
+        self.q.put(token)
 
     def on_llm_end(self, response: LLMResult, **kwargs) -> None:
         """Finish the Queue when the LLM is done."""
@@ -28,6 +27,8 @@ class StreamingQueueCallbackHandler(BaseCallbackHandler):
     def on_llm_error(
         self, error: Union[Exception, KeyboardInterrupt], **kwargs: Any
     ) -> None:
+        print("LLM ERROR", error)
+        self.q.put(self.end)
         """Run when LLM errors."""
 
     def on_chain_start(

--- a/compose/production/django/start
+++ b/compose/production/django/start
@@ -7,4 +7,4 @@ set -o nounset
 
 python /app/manage.py collectstatic --noinput
 python /app/manage.py migrate
-/usr/local/bin/gunicorn core.wsgi --bind 0.0.0.0:5000 --chdir=/app
+/usr/local/bin/gunicorn core.wsgi --bind 0.0.0.0:5000 --timeout 180 --chdir=/app


### PR DESCRIPTION
Firstly, the web timeout duration has been specified to 180 in the `Procfile` and `../compose/production/django/start` files by adding `--timeout 180` to the command.

Secondly, an error in handling italic text characters has been rectified by updating the regular expression used to identify the markup to ensure that the sanitized text remains free from such markup. 

Lastly, in case of any error with the LLM procedure, instead of stopping, a message is printed to indicate the error.