### PR TITLE
Revert back to streaming characters

### DIFF
--- a/ayushma/utils/stream_callback.py
+++ b/ayushma/utils/stream_callback.py
@@ -13,7 +13,8 @@ class StreamingQueueCallbackHandler(BaseCallbackHandler):
 
     def on_llm_new_token(self, token: str, **kwargs) -> None:
         """Run on new LLM token. Streams to Queue."""
-        self.q.put(token)
+        for char in token:
+            self.q.put(char)
 
     def on_llm_end(self, response: LLMResult, **kwargs) -> None:
         """Finish the Queue when the LLM is done."""


### PR DESCRIPTION
The frontend does not react very well to words being streamed instead of letters. This PR reverts to the previous behavior which was recently changed in https://github.com/coronasafe/ayushma/pull/125/files#diff-961da372eb0a93e078e46b4d3f3bb0f9682f5dd4c5d46bda0db4c2e4c3945dafL16-L17