### PR TITLE
Fix the endpoint to view project chats in order

### DIFF
--- a/ayushma/serializers/chat.py
+++ b/ayushma/serializers/chat.py
@@ -7,6 +7,7 @@ from ayushma.serializers.project import ProjectSerializer
 
 class ChatSerializer(serializers.ModelSerializer):
     project = ProjectSerializer(read_only=True)
+    username = serializers.CharField(source='user.username', read_only=True)
 
     class Meta:
         model = Chat
@@ -15,12 +16,14 @@ class ChatSerializer(serializers.ModelSerializer):
             "title",
             "created_at",
             "modified_at",
+            "username",
             "project",
         )
         read_only_fields = (
             "external_id",
             "created_at",
             "modified_at",
+            "username",
             "project",
         )
 

--- a/ayushma/serializers/chat.py
+++ b/ayushma/serializers/chat.py
@@ -109,12 +109,14 @@ class ConverseSerializer(serializers.Serializer):
 class ChatDetailSerializer(serializers.ModelSerializer):
     chats = serializers.SerializerMethodField()
     message = ConverseSerializer(required=False)
+    username = serializers.CharField(source='user.username', read_only=True)
 
     class Meta:
         model = Chat
         fields = (
             "external_id",
             "title",
+            "username",
             "created_at",
             "modified_at",
             "chats",
@@ -122,7 +124,7 @@ class ChatDetailSerializer(serializers.ModelSerializer):
             "message",
             "model",
         )
-        read_only_fields = ("external_id", "created_at", "modified_at", "chats")
+        read_only_fields = ("external_id", "created_at", "modified_at", "chats", "username")
 
     def get_chats(self, obj):
         chatmessages = ChatMessage.objects.filter(chat=obj).order_by("created_at")

--- a/ayushma/views/chat.py
+++ b/ayushma/views/chat.py
@@ -58,7 +58,9 @@ class ChatViewSet(
     def get_queryset(self):
         user = self.request.user
         project_id = self.kwargs["project_external_id"]
-        queryset = self.queryset.filter(project__external_id=project_id).order_by('-created_at')
+        queryset = self.queryset.filter(project__external_id=project_id).order_by(
+            "-created_at"
+        )
 
         if user.is_superuser and self.action == "list_all":
             return queryset
@@ -94,6 +96,16 @@ class ChatViewSet(
         queryset = self.get_queryset()
         serializer = self.get_serializer(queryset, many=True)
         return Response(serializer.data)
+
+    # @extend_schema(tags=["chats"])
+    # @action(detail=False, methods=["get"])
+    # def me(self, *args, **kwarg):
+    #     """Get user of each chat"""
+    #     chat = Chat.objects.get(external_id=kwarg["external_id"])
+    #     return chat.user
+        # user = User.object.filter
+        # return self.requeset.user
+        # return super().retrieve(*args, **kwargs)
 
     @extend_schema(
         tags=("chats",),

--- a/ayushma/views/chat.py
+++ b/ayushma/views/chat.py
@@ -58,7 +58,7 @@ class ChatViewSet(
     def get_queryset(self):
         user = self.request.user
         project_id = self.kwargs["project_external_id"]
-        queryset = self.queryset.filter(project__external_id=project_id)
+        queryset = self.queryset.filter(project__external_id=project_id).order_by('-created_at')
 
         if user.is_superuser and self.action == "list_all":
             return queryset

--- a/ayushma/views/chat.py
+++ b/ayushma/views/chat.py
@@ -97,16 +97,6 @@ class ChatViewSet(
         serializer = self.get_serializer(queryset, many=True)
         return Response(serializer.data)
 
-    # @extend_schema(tags=["chats"])
-    # @action(detail=False, methods=["get"])
-    # def me(self, *args, **kwarg):
-    #     """Get user of each chat"""
-    #     chat = Chat.objects.get(external_id=kwarg["external_id"])
-    #     return chat.user
-        # user = User.object.filter
-        # return self.requeset.user
-        # return super().retrieve(*args, **kwargs)
-
     @extend_schema(
         tags=("chats",),
     )


### PR DESCRIPTION
Partially Fixes #266 
- Allow the admin to fetch the chats under each project in descending order of creation

- Send username along with each chats to the admin for route `/api/projects/{project_external_id}/chats/{external_id}`
![image](https://github.com/coronasafe/ayushma/assets/70687348/4fac04d5-6cd1-4292-97ac-d37c05d8ce82)

- Send username along with chat titles to the admin for route `/api/projects/{project_external_id}/chats`
![image](https://github.com/coronasafe/ayushma/assets/70687348/937c8ab5-f71f-4d74-92ed-674620a176a6)

