### PR TITLE
Get all chats for fetch all request

### DIFF
--- a/ayushma/views/chat.py
+++ b/ayushma/views/chat.py
@@ -62,7 +62,7 @@ class ChatViewSet(
             "-created_at"
         )
 
-        if user.is_superuser and self.action == "list_all":
+        if user.is_superuser and (self.request.query_params.get('fetch') == "all" or self.action == "list_all"):
             return queryset
 
         return queryset.filter(user=user).order_by("-created_at")


### PR DESCRIPTION
Fixes #363 
If the request has a `fetch` parameter as `all` then don't filter the chats based on logged-in user.