### PR TITLE
Add check for empty recognized text in speech_to_text function

### DIFF
--- a/ayushma/utils/speech_to_text.py
+++ b/ayushma/utils/speech_to_text.py
@@ -91,7 +91,9 @@ def speech_to_text(engine_id, audio, language_code):
 
     try:
         engine = engine_class(api_key, language_code)
-        return engine.recognize(audio)
+        recognized_text = engine.recognize(audio)
+        if not recognized_text:
+            raise ValueError("Failed to detect any speech in provided audio")
     except Exception as e:
         print(f"Failed to recognize speech with {engine_name} engine: {e}")
         raise e


### PR DESCRIPTION
This pull request adds a check for empty recognized text in the speech_to_text function. If no speech is detected in the provided audio, a ValueError is raised. This helps to ensure that the function handles cases where no speech is present and prevents further processing of empty text.